### PR TITLE
make it possible to configure scripts with reversed exit codes

### DIFF
--- a/lib/renuo/bin-check/script_config.rb
+++ b/lib/renuo/bin-check/script_config.rb
@@ -1,6 +1,7 @@
 module RenuoBinCheck
   class ScriptConfig
-    attr_accessor :script_command, :script_files, :script_name
+    attr_accessor :script_command, :script_files, :script_name, :script_reversed_exit
+
     def command(command)
       @script_command = command
     end
@@ -13,8 +14,16 @@ module RenuoBinCheck
       @script_name = name
     end
 
+    def reversed_exit(reversed_exit)
+      @script_reversed_exit = reversed_exit
+    end
+
     def script_name
       @script_name ||= Digest::MD5.hexdigest(@script_command)
+    end
+
+    def reversed_exit?
+      @script_reversed_exit
     end
 
     def script_command

--- a/lib/renuo/bin-check/servant_thread.rb
+++ b/lib/renuo/bin-check/servant_thread.rb
@@ -20,8 +20,18 @@ module RenuoBinCheck
     end
 
     def run_command
+      @script.reversed_exit? ? run_reversed : run_normally
+    end
+
+    def run_normally
       Open3.popen3(@script.script_command) do |_stdin, stdout, stderr, wait_thr|
-        @result = CommandResult.new(stdout.read, stderr.read, wait_thr.value.exitstatus)
+        CommandResult.new(stdout.read, stderr.read, wait_thr.value.exitstatus)
+      end
+    end
+
+    def run_reversed
+      Open3.popen3(@script.script_command) do |_stdin, stdout, stderr, wait_thr|
+        CommandResult.new(stderr.read, stdout.read, wait_thr.value.exitstatus == 0 ? 1 : 0)
       end
     end
   end

--- a/lib/renuo/bin-check/servant_thread.rb
+++ b/lib/renuo/bin-check/servant_thread.rb
@@ -20,17 +20,13 @@ module RenuoBinCheck
     end
 
     def run_command
-      @script_config.reversed_exit? ? run_reversed : run_normally
+      output, error_output, process = Open3.capture3(@script_config.script_command)
+      @result = Result.new(output, error_output, process.exitstatus)
+      @script_config.reversed_exit? ? reverse_result : @result
     end
 
-    def run_normally
-      output, error_output, process = Open3.capture3(@script_config.script_command)
-      Result.new(output, error_output, process.exitstatus)
-    end
-
-    def run_reversed
-      output, error_output, process = Open3.capture3(@script_config.script_command)
-      Result.new(error_output, output, process.exitstatus == 0 ? 1 : 0)
+    def reverse_result
+      Result.new(@result.error_output, @result.output, @result.exit_code == 0 ? 1 : 0)
     end
   end
 end

--- a/spec/factories/command_result.rb
+++ b/spec/factories/command_result.rb
@@ -6,6 +6,12 @@ FactoryGirl.define do
     exit_code 0
     initialize_with { new(output, error_output, exit_code) }
 
+    factory :reversed_exit_result do
+      error_output "I passed\nThis is the second line\n"
+      output "I failed\nThis is the second line\n"
+      exit_code 1
+    end
+
     factory :failed_result do
       exit_code 1
     end

--- a/spec/factories/script_config.rb
+++ b/spec/factories/script_config.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     script_command 'cool command'
     script_name 'script_name'
     script_files %w(cool_file1 cool_file1)
+    script_reversed_exit false
 
     factory :failing_script do
       script_command './spec/spec-files/test_script_exit1'
@@ -16,6 +17,10 @@ FactoryGirl.define do
 
       factory :without_files_script do
         script_files nil
+      end
+
+      factory :reversed_exit_script do
+        script_reversed_exit true
       end
     end
 

--- a/spec/factories/script_config.rb
+++ b/spec/factories/script_config.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     script_command 'cool command'
     script_name 'script_name'
     script_files %w(cool_file1 cool_file1)
-    script_reversed_exit false
 
     factory :failing_script do
       script_command './spec/spec-files/test_script_exit1'

--- a/spec/integration/initializer_spec.rb
+++ b/spec/integration/initializer_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe RenuoBinCheck::Initializer do
         end
       end.to output("I passed\nThis is the second line\n").to_stdout
     end
+
+    it 'runns the whole application as expected using a one liner command' do
+      bin_check.check do |config|
+        config.command "grep -i -r 'console.lo' lib spec"
+        config.name 'exit0'
+        config.files %w(file1 file2)
+      end
+      expect do
+        begin
+          bin_check.run
+        rescue SystemExit => se
+          expect(se.status).to eq(0)
+        end
+      end.to output.to_stdout
+    end
   end
 
   context 'failing script' do

--- a/spec/renuo/bin-check/script_config_spec.rb
+++ b/spec/renuo/bin-check/script_config_spec.rb
@@ -2,22 +2,26 @@ require 'spec_helper'
 require './lib/renuo/bin-check/script_config'
 
 RSpec.describe RenuoBinCheck::ScriptConfig do
+  let(:script) { RenuoBinCheck::ScriptConfig.new }
+
   it 'sets command' do
-    script = RenuoBinCheck::ScriptConfig.new
     script.command 'super cool command'
     expect(script.script_command).to eq('super cool command')
   end
 
   it 'sets files' do
-    script = RenuoBinCheck::ScriptConfig.new
     script.files(['first file', 'second file'])
     expect(script.script_files).to eq(['first file', 'second file'])
   end
 
   it 'sets name and returns it' do
-    script = RenuoBinCheck::ScriptConfig.new
     script.name('nice_script')
     expect(script.script_name).to eq('nice_script')
+  end
+
+  it 'sets reversed_exit' do
+    script.reversed_exit(true)
+    expect(script.reversed_exit?).to be_truthy
   end
 
   context 'params not set' do

--- a/spec/renuo/bin-check/servant_thread_spec.rb
+++ b/spec/renuo/bin-check/servant_thread_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe RenuoBinCheck::ServantThread do
     let(:script) { build :passing_script }
     let(:servant) { RenuoBinCheck::ServantThread.new(script) }
 
+    after(:each) { FileUtils.remove_dir('./tmp/bin-check/exit0') }
+
     it 'starts the command defined in ScriptConfig and returns a Result' do
       expect(servant.run).to have_attributes(result_attributes)
     end
@@ -29,6 +31,18 @@ RSpec.describe RenuoBinCheck::ServantThread do
   context 'without file' do
     let(:script) { build :without_files_script }
     let(:servant) { RenuoBinCheck::ServantThread.new(script) }
+
+    it 'starts the command defined in ScriptConfig and returns a Result' do
+      expect(servant.run).to have_attributes(result_attributes)
+    end
+  end
+
+  context 'with reversed_exit' do
+    let(:script) { build :reversed_exit_script }
+    let(:servant) { RenuoBinCheck::ServantThread.new(script) }
+    let(:result_attributes) { attributes_for :reversed_exit_result }
+
+    after(:each) { FileUtils.remove_dir('./tmp/bin-check/exit0') }
 
     it 'starts the command defined in ScriptConfig and returns a Result' do
       expect(servant.run).to have_attributes(result_attributes)


### PR DESCRIPTION
	- add attributes to ScriptConfig
	- add new factory for ScriptConfig with reversed_exit that is true
	- make ServantThread set the outputs/error-outputs/exit codes the right way