### PR TITLE
Add config folder to rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,14 @@ Style/FileName:
   Exclude:
   - 'Gemfile.local.rb'
   - 'Gemfile.local.example.rb'
-  
+
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Metrics/BlockLength:
+  Enabled: true
+  Exclude:
+    - spec/**/*
 
 AllCops:
   TargetRubyVersion: 2.3

--- a/lib/renuo_bin_check/bin_check.rb
+++ b/lib/renuo_bin_check/bin_check.rb
@@ -2,6 +2,7 @@ require 'renuo_bin_check/dsl_config'
 require 'renuo_bin_check/default_scripts/default_scripts'
 
 class BinCheck
+  # rubocop:disable Style/MethodMissing
   def self.method_missing(name, *_params, &configs)
     if block_given?
       @configs << DSLConfig.new(name.to_s, &configs)
@@ -9,6 +10,7 @@ class BinCheck
       super
     end
   end
+  # rubocop:enable Style/MethodMissing
 
   def self.respond_to_missing?(_name, *_params)
     true

--- a/lib/renuo_bin_check/bin_check.rb
+++ b/lib/renuo_bin_check/bin_check.rb
@@ -2,7 +2,6 @@ require 'renuo_bin_check/dsl_config'
 require 'renuo_bin_check/default_scripts/default_scripts'
 
 class BinCheck
-  # rubocop:disable Style/MethodMissing
   def self.method_missing(name, *_params, &configs)
     if block_given?
       @configs << DSLConfig.new(name.to_s, &configs)
@@ -10,7 +9,6 @@ class BinCheck
       super
     end
   end
-  # rubocop:enable Style/MethodMissing
 
   def self.respond_to_missing?(_name, *_params)
     true

--- a/lib/renuo_bin_check/default_scripts/default_scripts.rb
+++ b/lib/renuo_bin_check/default_scripts/default_scripts.rb
@@ -107,7 +107,7 @@ class DefaultScripts
   def rubocop_autocorrect
     @default_scripts << DSLConfig.new('rubocop_autocorrect') do
       command 'bundle exec rubocop -a -D -c .rubocop.yml'
-      files ['app/**/*.rb', 'spec/**/*.rb']
+      files ['app/**/*.rb', 'spec/**/*.rb', 'config/**/*.rb']
     end
   end
 

--- a/spec/renuo/bin-check/default_scripts/default_scripts_spec.rb
+++ b/spec/renuo/bin-check/default_scripts/default_scripts_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe DefaultScripts do
       .to eq(
         name: 'rubocop_autocorrect',
         command: 'bundle exec rubocop -a -D -c .rubocop.yml',
-        files: ['app/**/*.rb', 'spec/**/*.rb']
+        files: ['app/**/*.rb', 'spec/**/*.rb', 'config/**/*.rb']
       )
   end
 


### PR DESCRIPTION
It seems that rubocop can have different versions locally or on the ci, I created a issue for it: https://github.com/renuo/renuo-bin-check/issues/33